### PR TITLE
Make history-component iframe responsive.

### DIFF
--- a/src/app/pages/history/history.component.html
+++ b/src/app/pages/history/history.component.html
@@ -4,7 +4,7 @@
       <p>{{data.date}}</p>
       <p>{{data.title}}</p>
       <p [innerHTML]="data.desc"></p>
-      <p *ngIf="data.type == 'twitter'" style="width: 560px; height: 315px;">
+      <p class="iframe-wrap" *ngIf="data.type == 'twitter'">
         <iframe *ngIf="!loading" width="560" height="315"
                 [src]="sanitize('https://twitter-embed.arkjp.net/?url=' + data?.url)"
                 frameborder="0"
@@ -12,7 +12,7 @@
                 allowfullscreen></iframe>
         <img *ngIf="loading" src="/assets/img/loading.png" alt="loading" width="560" height="315">
       </p>
-      <p *ngIf="data.type == 'youtube'" style="width: 560px; height: 315px;">
+      <p class="iframe-wrap" *ngIf="data.type == 'youtube'">
         <iframe *ngIf="!loading" width="560" height="315" [src]="sanitize(data?.url)" frameborder="0"
                 loading="lazy"
                 allowfullscreen>

--- a/src/app/pages/history/history.component.scss
+++ b/src/app/pages/history/history.component.scss
@@ -7,3 +7,18 @@ history-component {
   display: block;
   width: 100%;
 }
+
+.iframe-wrap {
+  position: relative;
+  padding-bottom: 56.25%; /*アスペクト比 16:9の場合の縦幅*/
+  height: 0;
+  overflow: hidden;
+}
+
+.iframe-wrap * {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/app/pages/history/history.component.scss
+++ b/src/app/pages/history/history.component.scss
@@ -13,12 +13,12 @@ history-component {
   padding-bottom: 56.25%; /*アスペクト比 16:9の場合の縦幅*/
   height: 0;
   overflow: hidden;
-}
 
-.iframe-wrap * {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  * {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 }


### PR DESCRIPTION
I thought it would be better to make the "iframe" responsive.
I messily named classes.

beta
![history_unresponsive_iframe](https://user-images.githubusercontent.com/70041621/95670204-5e169a80-0bc3-11eb-8273-fdf09aacad7f.png)
beta-oger
![history_responsive_iframe](https://user-images.githubusercontent.com/70041621/95670315-85ba3280-0bc4-11eb-82d0-1253226bcbe5.png)

